### PR TITLE
Add string method to trim whitespace

### DIFF
--- a/string.go
+++ b/string.go
@@ -6,6 +6,7 @@ package optional
 import (
 	"encoding/json"
 	"errors"
+	"strings"
 )
 
 // String is an optional string.
@@ -57,6 +58,13 @@ func (s String) OrElse(v string) string {
 func (s String) If(fn func(string)) {
 	if s.Present() {
 		fn(*s.value)
+	}
+}
+
+// Trim the whitespace from the string value if the value is present.
+func (s String) Trim() {
+	if s.Present() {
+		*s.value = strings.TrimSpace(*s.value)
 	}
 }
 

--- a/string_test.go
+++ b/string_test.go
@@ -79,6 +79,35 @@ func TestString_If_NotPresent(t *testing.T) {
 	assert.False(t, canary)
 }
 
+func TestString_Trim(t *testing.T) {
+	o := String{}
+	o.Trim()
+
+	o.Set(" This is a string! ")
+	o.Trim()
+	assert.Equal(t, NewString("This is a string!"), o)
+
+	o.Set("       _sTrInG123- ")
+	o.Trim()
+	assert.Equal(t, "_sTrInG123-", o.MustGet())
+
+	o.Set(" @optional:         ")
+	o.Trim()
+	assert.Equal(t, "@optional:", o.MustGet())
+
+	o.Set("                   ")
+	o.Trim()
+	assert.Equal(t, "", o.MustGet())
+
+	o.Set("")
+	o.Trim()
+	assert.Equal(t, "", o.MustGet())
+
+	o.Set("a")
+	o.Trim()
+	assert.Equal(t, "a", o.MustGet())
+}
+
 func TestString_MarshalJSON(t *testing.T) {
 	type fields struct {
 		WithValue     String


### PR DESCRIPTION
This PR adds a method to trim the whitespace from optional.String type.  The built-in `strings.Trim()` function does not work for the optional.String types.  

	o := NewString("  This is a string.  ")
	o.Trim()

After the Trim() function is called, the value of `o` is `This is a string.`.  The outer whitespace has been trimmed.